### PR TITLE
deprecated slack api update

### DIFF
--- a/slack_helper.py
+++ b/slack_helper.py
@@ -32,7 +32,7 @@ def find_slack_message_for_update(pipeline_execution_id):
 
 
 def find_channel_id(channel_name):
-    res = slack_client.api_call("channels.list", exclude_archived=1)
+    res = slack_client.api_call("conversations.list", exclude_archived=1)
 
     if 'error' in res:
         if not isinstance(res['error'], str):
@@ -51,7 +51,7 @@ def find_channel_id(channel_name):
 
 
 def get_slack_messages_from_channel(channel_id):
-    res = slack_client.api_call('channels.history', channel=channel_id)
+    res = slack_client.api_call('conversations.history', channel=channel_id)
 
     if 'error' in res:
         if not isinstance(res['error'], str):


### PR DESCRIPTION
vendor: deprecated slack api update

- channels.list -> conversations.list
- channels.history -> conversations.history

안녕하세요! AWS CodePipeline을 사용하면서 슬랙과의 연동이 필요해서 사용하게 되었는데,
deprecated된 API로 인해 에러가 발생해서 수정한 내용을 PR합니다!

[channels.list](https://api.slack.com/methods/channels.list)
[channels.history](https://api.slack.com/methods/channels.history)

커밋 컨벤션이 따로 명시되어 있지 않아 임의로 커밋 내용을 작성했는데, 수정이 필요한 부분이 있다면 말씀해주세요.

\+ 편하게 사용할 수 있게 해주셔서 감사합니다 😄 