### PR TITLE
fix for find_slack_message_for_update

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,5 @@
 stage="dev"
 s3_bucket=""
-SLACK_TOKEN=""
 SLACK_BOT_TOKEN=""
 SLACK_BOT_NAME="PipelineBot"
 SLACK_BOT_ICON=":robot_face:"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ install your bot to your workspace
 
 Click your app > OAuth & Permissions
 
-Copy **OAuth Access** **Token** and **Bot User OAuth Access** **Token** and paste it to .env
+Copy **Bot User OAuth Access** **Token** and paste it to .env
 
 
 
@@ -77,7 +77,7 @@ you need to register your environment variables in .env file.
 
 - stage: your cloud stage environment. like `dev`, `prd`. This parameter insert to lambda funciton name like `codepipeline-slack-dev-notifier`
 - s3_bucket: s3 bucket name. Serverless artifacts will be uploaded to this bucket.
-- SLACK_BOT_TOKEN:  Slack token. Bot User Oauth Access Token.
+- SLACK_BOT_TOKEN:  Bot User Oauth Access Token.
 - SLACK_CHANNEL: slack channel to send pipeline status message. defualt is `builds`
 - SLACK_BOT_NAME: your slack bot name. default is `PipelineBot`
 - SLACK_BOT_ICON: your slack bot's icon. default is `:robot_face:`

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ you have to set bot's api permission scopes.
 
 Click your app > OAuth & Permissions
 
-Add Permissions
+Bot Token Scopes
 
 - channels:history
 - channels:read
-- chat:write:bot
-- chat:write:user
+- chat:write
+
+User Token Scopes
+
+- none
 
 ![image:](slack_permission.png)
 
@@ -74,7 +77,6 @@ you need to register your environment variables in .env file.
 
 - stage: your cloud stage environment. like `dev`, `prd`. This parameter insert to lambda funciton name like `codepipeline-slack-dev-notifier`
 - s3_bucket: s3 bucket name. Serverless artifacts will be uploaded to this bucket.
-- SLACK_TOKEN: Slack token. OAuth Access Token.
 - SLACK_BOT_TOKEN:  Slack token. Bot User Oauth Access Token.
 - SLACK_CHANNEL: slack channel to send pipeline status message. defualt is `builds`
 - SLACK_BOT_NAME: your slack bot name. default is `PipelineBot`

--- a/message_builder.py
+++ b/message_builder.py
@@ -158,7 +158,7 @@ class MessageBuilder:
         external_execution_url = action_states['latestExecution']['externalExecutionUrl']
 
         if external_execution_url:
-            self.get_or_create_action(f"Dashboard:{build_project_name}", external_execution_url)
+            self.get_or_create_action(f"Dashboard: {build_project_name}", external_execution_url)
 
         build_field_name = MessageBuilder.create_codebuild_name_from_pipeline_stage(
             stage_name, build_project_name

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,5 +1,3 @@
-org: strutive07
-app: codepipeline-slack-notifier
 # Welcome to Serverless!
 #
 # This file is the main config file for your service.
@@ -21,7 +19,7 @@ environment:
 provider:
   name: aws
   runtime: python3.6
-  region: ap-northeast-2
+  region: eu-west-1
   stage: ${env:stage}
   deploymentBucket: ${env:s3_bucket}
 
@@ -37,7 +35,6 @@ provider:
       Resource: '*'
 
   environment:
-    SLACK_TOKEN: ${env:SLACK_TOKEN}
     SLACK_BOT_TOKEN: ${env:SLACK_BOT_TOKEN}
     SLACK_BOT_NAME: ${env:SLACK_BOT_NAME}
     SLACK_BOT_ICON: ${env:SLACK_BOT_ICON}

--- a/slack_helper.py
+++ b/slack_helper.py
@@ -5,7 +5,6 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-slack_client = SlackClient(os.getenv("SLACK_TOKEN"))
 sc_bot = SlackClient(os.getenv("SLACK_BOT_TOKEN"))
 SLACK_CHANNEL = os.getenv("SLACK_CHANNEL", "builds_test")
 SLACK_BOT_NAME = os.getenv("SLACK_BOT_NAME", "PipelineBot")
@@ -17,7 +16,7 @@ def find_slack_message_for_update(pipeline_execution_id):
     slack_messages = get_slack_messages_from_channel(channel_id=channel_id)
 
     for message in slack_messages:
-        if message.get('username', '') != SLACK_BOT_NAME:
+        if 'bot_profile' not in message:
             continue
 
         attachments = message.get('attachments', [])
@@ -32,7 +31,7 @@ def find_slack_message_for_update(pipeline_execution_id):
 
 
 def find_channel_id(channel_name):
-    res = slack_client.api_call("conversations.list", exclude_archived=1)
+    res = sc_bot.api_call("conversations.list", exclude_archived=1)
 
     if 'error' in res:
         if not isinstance(res['error'], str):
@@ -51,7 +50,7 @@ def find_channel_id(channel_name):
 
 
 def get_slack_messages_from_channel(channel_id):
-    res = slack_client.api_call('conversations.history', channel=channel_id)
+    res = sc_bot.api_call('conversations.history', channel=channel_id)
 
     if 'error' in res:
         if not isinstance(res['error'], str):
@@ -64,7 +63,7 @@ def get_slack_messages_from_channel(channel_id):
 
 
 def update_message(channel_id, message_id, attachments):
-    res = slack_client.api_call(
+    res = sc_bot.api_call(
         "chat.update",
         channel=channel_id,
         ts=message_id,
@@ -84,7 +83,7 @@ def update_message(channel_id, message_id, attachments):
 
 
 def send_message(channel_id, attachments):
-    res = slack_client.api_call(
+    res = sc_bot.api_call(
         "chat.postMessage",
         channel=channel_id,
         icon_emoji=SLACK_BOT_ICON,

--- a/slack_helper.py
+++ b/slack_helper.py
@@ -32,7 +32,7 @@ def find_slack_message_for_update(pipeline_execution_id):
 
 
 def find_channel_id(channel_name):
-    res = slack_client.api_call("channels.list", exclude_archived=1)
+    res = slack_client.api_call("conversations.list", exclude_archived=1)
 
     if 'error' in res:
         if not isinstance(res['error'], str):
@@ -51,7 +51,7 @@ def find_channel_id(channel_name):
 
 
 def get_slack_messages_from_channel(channel_id):
-    res = slack_client.api_call('channels.history', channel=channel_id)
+    res = slack_client.api_call('conversations.history', channel=channel_id)
 
     if 'error' in res:
         if not isinstance(res['error'], str):


### PR DESCRIPTION
README.md
changed to reflect the permission changes and removed env var

serverless.yml
removed org and app so you don't have to login and use the serverless platform.

slack_helper.py
with the way slack now sets auth permissions, we only need the bot token and associated permissions
username does not exist in the json payload of the message, however bot_profile does when it is a message from a bot